### PR TITLE
Fixed variable scope for `key`

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -17,7 +17,7 @@ exports.key = '';
 
 exports.sign = function(payload, secretOrPrivateKey, options) {
     var settings = {};
-    settings.expiresInMinutes = 1;
+    settings.expiresInMinutes = 60;
     settings = Hoek.applyToDefaults(settings, options);
 
     Hoek.assert(payload, 'Missing payload');

--- a/lib/index.js
+++ b/lib/index.js
@@ -17,7 +17,7 @@ exports.key = '';
 
 exports.sign = function(payload, secretOrPrivateKey, options) {
     var settings = {};
-    settings.expiresInMinutes = 60;
+    settings.expiresInMinutes = 1;
     settings = Hoek.applyToDefaults(settings, options);
 
     Hoek.assert(payload, 'Missing payload');
@@ -44,7 +44,16 @@ internals.implementation = function(server, options) {
         );
     }
 
-    Hoek.assert(settings.key, 'Missing privateKey');
+    if (settings.hasOwnProperty('key')) {
+        Hoek.assert(
+            typeof settings.key === 'string',
+            'options.key must be a string, or needs to be set by using sign() first'
+        );
+
+        exports.key = settings.key;
+    }
+
+    Hoek.assert(exports.key, 'Missing privateKey');
 
     return {
         authenticate: function(request, reply) {
@@ -64,7 +73,7 @@ internals.implementation = function(server, options) {
 
             var token = parts[1];
 
-            jwt.verify(token, settings.key, options, function(err, decoded) {
+            jwt.verify(token, exports.key, options, function(err, decoded) {
                 if (err && err.message === 'jwt expired') {
                     return reply(Boom.unauthorized('Token expired', 'Bearer'));
                 } else if (err) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -44,7 +44,7 @@ internals.implementation = function(server, options) {
         );
     }
 
-    Hoek.assert(exports.key, 'Missing privateKey');
+    Hoek.assert(settings.key, 'Missing privateKey');
 
     return {
         authenticate: function(request, reply) {
@@ -64,7 +64,7 @@ internals.implementation = function(server, options) {
 
             var token = parts[1];
 
-            jwt.verify(token, exports.key, options, function(err, decoded) {
+            jwt.verify(token, settings.key, options, function(err, decoded) {
                 if (err && err.message === 'jwt expired') {
                     return reply(Boom.unauthorized('Token expired', 'Bearer'));
                 } else if (err) {


### PR DESCRIPTION
Maybe the way I have implemented the module is just wrong, but I was not able to get even the setup right — the server was crashing with an error stating that `key` is missing …

If using the `settings.key` instead of `exports.key` the module works as expected.
